### PR TITLE
Allow developers to modify the version of google-service

### DIFF
--- a/platforms/android/include.gradle
+++ b/platforms/android/include.gradle
@@ -8,5 +8,6 @@ android {
 }
 
 dependencies {
-	compile 'com.google.android.gms:play-services-ads:8.3.0'
+    def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : '10.2.+'
+	compile "com.google.android.gms:play-services-ads:$googlePlayServicesVersion"
 }


### PR DESCRIPTION
I was using your plug-in and had difficulties with the hard-coded version. I changed the code to use the same pattern as `nativescript-plugin-firebase` allowing to change the version number in `app.gradle`.